### PR TITLE
Fix version of chalk library to 4.1.2 or lower

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-bundle-analyzer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cra-bundle-analyzer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Sven Gaubert",
   "description": "Use Webpack Bundle Analyzer on a create-react-app application without ejecting",
   "main": "src/index.js",
@@ -31,7 +31,7 @@
     "webpack-bundle-analyzer": "^3.6.0"
   },
   "peerDependencies": {
-    "chalk": ">=3",
+    "chalk": ">=3 <=4.1.2",
     "react-scripts": ">=3",
     "webpack": ">=4"
   }


### PR DESCRIPTION
Hello, I am using "cra-bundle-analyzer" well.
But, there is a problem recently.

### Issue
- Recently(26 Nov 2021), version 5.0.0 of the chalk library was released. Key breaking change is that the library was changed to pure ESM. (https://github.com/chalk/chalk/releases/tag/v5.0.0)
- So I'm getting the following error:
<img width="882" alt="error message" src="https://user-images.githubusercontent.com/8624075/147881523-640822e6-808d-42db-b17b-08ff21d250bd.png">

### Solve
- Restrict the version of chalk library in peerDependencies to 4.1.2 or lower.

Please check the PR and comment.
Thank you.
